### PR TITLE
Fix RAM leak caused by itertools.cycle in dataloader

### DIFF
--- a/train.py
+++ b/train.py
@@ -55,7 +55,8 @@ def training(dataset, opt, pipe, render_iteraions, testing_iterations, testing_s
     train_dataset = scene.getTrainCameras()
     print("Batch size: {}".format(opt.batch_size))
     dataloader = DataLoader(train_dataset, batch_size=opt.batch_size, sampler=RandomSampler(train_dataset, replacement=True), num_workers=4, pin_memory=True, drop_last=True)
-    data_iterator = cycle(dataloader)
+    # NOTE: use iter rather than cycle(dataloader)
+    data_iterator = iter(dataloader)
 
     if evaluate:
         test_dataset = scene.getTestCameras()
@@ -88,10 +89,16 @@ def training(dataset, opt, pipe, render_iteraions, testing_iterations, testing_s
 
         gaussians.update_learning_rate(iteration)
 
-        # Pick a random Camera
+        # NOTE: Pick a random Camera, solved RAM leak by cycle(dataloader)
         if camera_batch is None or iteration % len(camera_batch["uid"]) == 0:
             batch_index = 0
-            camera_batch = next(data_iterator)
+            try:
+                camera_batch = next(data_iterator)
+            except StopIteration:
+                data_iterator = iter(dataloader)
+                camera_batch = next(data_iterator)
+
+
            
         viewpoint_cam = {key: value[batch_index] if not isinstance(value, torch.Tensor) else value[batch_index].cuda() for key, value in camera_batch.items()}
         batch_index += 1


### PR DESCRIPTION
### Description
This PR addresses a severe system memory (RAM) leak encountered during training. Previously, RAM usage would increase linearly until the OS killed the process. 

### Cause
The issue stems from the use of `itertools.cycle(dataloader)` in the training loop. `itertools.cycle` caches the outputs of the iterable during the first pass. In this context, where the dataloader returns large tensors (high-res images, masks, etc.), this causes the entire dataset to be cached in RAM, inevitably leading to OOM crashes.

### Changes Made
* Replaced `itertools.cycle` with a standard `iter(dataloader)` initialization.
* Added a `try-except StopIteration` block inside the training loop to manually reset the iterator when the dataloader is exhausted. 
* This allows Python's Garbage Collector to properly release memory from previous epochs.

### Environment Tested
* **OS:** Ubuntu 24.04
* **CUDA:** 11.8
* **PyTorch:** 2.0.0+cu118
* **RAM:** 64GB
* **GPU:** NVIDIA RTX 4090 24GB

Fixes #6 
